### PR TITLE
fixing xss in exhibits editor

### DIFF
--- a/ndxzstudio/module/exhibits/edits.js
+++ b/ndxzstudio/module/exhibits/edits.js
@@ -248,6 +248,7 @@ function updateText(ida)
 	{
 		// silly that it really needs 'name' instead of 'id'
 		var text = tinyMCE.getInstanceById('content').getHTML();
+		text = text.replace("<script>", "") // Simple XSS Protection
 	}
 	
 	$.post('?a='+action, { upd_jxtext : 'true', v : text, id : ida }, 


### PR DESCRIPTION
The exhibits of this cms don't really sanitize the userinput for javascript code, allowing potential XSS to happen. A potential target for XSS could be the ndxz_access and ndxz_hash cookies, allowing an attacker to steal cookies and impersonate other users. 

This fix is only exemplary for simple javascript tags in the text editor. I would recommend including a anti-xss library and sanitizing every user input.

Best regards,
Alex